### PR TITLE
Add `packageManager` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
   "dependencies": {
     "minimist": "^1.2.6",
     "patch-package": "^6.5.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
Explicitly asking for Yarn v1 prevents Popmenu CI from trying to build this with Yarn v4.